### PR TITLE
fix: update deprecated `include` with `import_tasks`

### DIFF
--- a/tasks/agent-register/create-activation.yml
+++ b/tasks/agent-register/create-activation.yml
@@ -10,7 +10,7 @@
   when: "aws_ssm_activation_code is defined or aws_ssm_activation_id is defined"
 
 # Detecting the current AWS Region to use.
-- include: region-detect/main.yml
+- import_tasks: region-detect/main.yml
   when: aws_ssm_ec2_region is not defined
 
 # Creating a new IAM Managed policy to be attached to

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,11 @@
   when: ansible_pkg_mgr is not defined and ansible_os_family != 'Windows'
 
 # Installs the AWS SSM Agent software.
-- include: agent-install/main.yml
+- import_tasks: agent-install/main.yml
   tags:
     - install-agent
 
 # Registers the SSM Agent on AWS SSM.
-- include: agent-register/main.yml
+- import_tasks: agent-register/main.yml
   tags:
     - register-agent


### PR DESCRIPTION
Fixing the following error

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

The error appears to be in '/Users/deshan/Developer/KZN/supagolf-tee-management-webapp/rpi/roles/aws_ssm_agent/tasks/main.yml': line 10, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

# Installs the AWS SSM Agent software.
- include: agent-install/main.yml
  ^ here
```